### PR TITLE
feature: restructure app to handle more than one channel

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 .idea
 src
 __tests__
+coverage
 
 # Files
 jest.config.ts

--- a/README.md
+++ b/README.md
@@ -12,19 +12,9 @@ This comes right from the README on ```node-amqp-connection-manager```:
 > * Supports both promises and callbacks (using promise-breaker)
 > * Very un-opinionated library—a thin wrapper around amqplib.
 
-## Notice
-
-This NPM package is still going **active development** so things will break. Review the issues list for on going development work and if you want to help out, submit a PR.
-
-Help Wanted:
-* Documentation
-* GitHub Workflows
-* Unit Testing using Jest
-
 ## Table of Contents
 
-1. [Notice](#notice)
-2. [Install](#install)
+1. [Install](#install)
 2. [Basic Usage](#basic-usage)
 3. [Full Documentation](#full-documentation)
    1. [Options](#options)
@@ -33,9 +23,11 @@ Help Wanted:
 
 ## Install
 ```
-npm i fastify-rabbitmq amqplib
-npm i --save-dev @types/amqplib
+npm i fastify-rabbitmq
 ```
+
+Plugin includes all needed functions and exports from the ```amqplib``` library
+without having to bring it into your project.
 
 ## Basic Usage
 Register this as a plugin.
@@ -44,38 +36,58 @@ Make sure it is loaded before any ***routes*** are loaded.
 ### Quick Setup on the Server Side
 
 ```typescript
-export default fp<any>(async (fastify: FastifyInstance, options: FastifyPluginOptions) => {
+export default fp<FastifyPluginOptions>((fastify, options, done) => {
   
    fastify.register(fastifyRabbit, {
       urLs: ['amqp://localhost']
    })
 
-   fastify.ready().then(async () => {
-      fastify.log.debug('[rabbitmq] Started RabbitMQ')
-      fastify.rabbitmq.channel = fastify.rabbitmq.createChannel({
-         json: true,
-         setup: function (channel: ConfirmChannel) {
-            return Promise.all([
-               channel.assertQueue('server', {durable: true}),
-               channel.prefetch(1),
-               channel.consume('server', async (message) => {
-                  fastify.log.debug(JSON.stringify(data))
-                  fastify.rabbitmq.channel?.ack(message);
-               })
-            ]);
-         },
-      })
-   })
+   fastify.rabbitmq.on('connect', function (result) {
+      // on connect, do something here?
+   });
+
+   fastify.rabbitmq.on('disconnect', function (err) {
+      // on disconnect, do something here?
+   });
+
+   const LISTEN_QUEUE_NAME = 'bar'
+
+   // create the channel 'bar'
+   app.rabbitmq.createChannel({
+      name: LISTEN_QUEUE_NAME,
+      setup: function(channel: Channel) {
+         return Promise.all([
+            channel.assertQueue(LISTEN_QUEUE_NAME, {durable: true}),
+            channel.prefetch(1),
+            channel.consume(LISTEN_QUEUE_NAME, onMessage)
+         ]);
+      }
+   });
+
+   const onMessage = function(data: ConsumeMessage) {
+      const message = JSON.parse(data.content.toString());
+      channelWrapper.ack(data);
+      expect(message).toBe(DATE)
+   }
    
 });
 ```
 
-Within server instance can also call the same queue as long as it has access to the ``fastify.rabbitmq`` decorator.
-Traditionally, a separate app is running and is the client sending messages to the client.
+Within any "endpoint" function, or if you have access to ```fastify.rabbitmq``` you can then call:
+
+```js
+fastify.get('/rabbitmq', async (request, reply) => {
+  const getChannel = fastify.rabbitmq.findChannel('bar');
+  await getChannel?.sendToQueue('bar', {time: DATE})
+})
+```
+
+Sending the time to another queue called ```bar``` from the queue ```foo````.
 
 ### Quick Setup on the Client Side
 
-First set up your plugin to register the plugin.
+Using the above example server code above, up your plugin to register the plugin.
+This could be on the same service as the server or another service all together.
 
 ```typescript
 import {ConfirmChannel} from "amqplib";
@@ -86,47 +98,51 @@ import {
 import fp from "fastify-plugin";
 import fastifyRabbit from "fastify-rabbitmq"
 
-export default fp<any>(async (fastify: FastifyInstance, options: FastifyPluginOptions) => {
+export default fp<FastifyPluginOptions>((fastify, options, done) => {
 
   fastify.register(fastifyRabbit, {
     urLs: ['amqp://localhost']
   })
 
-  fastify.ready().then(async () => {
+   const LISTEN_QUEUE_NAME = 'bar'
 
-    fastify.rabbitmq.channel = fastify.rabbitmq.createChannel({
-      json: true,
-      setup: function (channel: ConfirmChannel) {
-        return channel.assertQueue('client', { durable: true });
+   // create the channel 'bar'
+   const channelWrapper = app.rabbitmq.createChannel({
+      name: LISTEN_QUEUE_NAME,
+      setup: function(channel: Channel) {
+         return Promise.all([
+            channel.assertQueue(LISTEN_QUEUE_NAME, {durable: true}),
+            channel.prefetch(1),
+            channel.consume(LISTEN_QUEUE_NAME, onMessage)
+         ]);
       }
-    });
+   });
 
-  })
-
+   const onMessage = function(data: ConsumeMessage) {
+      const message = JSON.parse(data.content.toString());
+      channelWrapper.ack(data);
+   }
+   
+   done()
 })
 ```
-
-Now in your routes or anywhere the fastify.rabbitmq can be accessed:
-
-```typescript
-fastify.get('/rabbitmq', {}, async (request, reply) => {
-   try {
-      fastify.rabbitmq.channel?.sendToQueue('server', { foo: 'bar'})
-      return reply.code(200).send({ result: true});
-   } catch (error) {
-      return reply.send(404);
-   }
-});
-```
-
 ## Full Documentation
 
 ### Options
 
 ```typescript
-export interface FastifyRabbitMQOptions extends AmqpConnectionManagerOptions {
+export interface FastifyRabbitMQOptions extends FastifyPluginOptions {
+   /**
+    * Log Level for RabbitMQ Debugging
+    */
    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
+   /**
+    * Namespace
+    */
    namespace?: string
+   /**
+    * Connection URLS for IAmqpConnectionManager
+    */
    urLs: ConnectionUrl | ConnectionUrl[] | undefined | null
 }
 ```
@@ -156,7 +172,7 @@ This is not needed
 if you use AmqpConnectionManagerOptions [findServers](https://github.com/jwalton/node-amqp-connection-manager#connecturls-options)
 which overrides the urls value if it's set.
 If you need
-to pass in credentials to the RabbitMQ or vHost for the connection review the [connection options](#amqpconnectionmanageroptions).
+to pass in credentials to the RabbitMQ or vHost for the connection review [connection options](#amqpconnectionmanageroptions).
 
 Please review the options [here](https://github.com/jwalton/node-amqp-connection-manager/blob/master/src/AmqpConnectionManager.ts#L26C13-L26C34).
 (Note:
@@ -171,7 +187,7 @@ See [Connection Options](https://github.com/jwalton/node-amqp-connection-manager
 
 - [node-amqp-connection-manager](https://github.com/jwalton/node-amqp-connection-manager)
 - [fastify](https://fastify.dev/)
-- ...and of course my Wife and Baby Girl.
+- ... and my Wife and Baby Girl.
 
 ## License
 

--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -1,0 +1,41 @@
+import fastify, {FastifyInstance} from "fastify";
+import fastifyRabbit from "../src";
+
+describe('fastify-rabbitmq sample app tests',  () => {
+
+  describe("create a receiver and a sender",  () => {
+
+    let app: FastifyInstance;
+
+    beforeAll(() => {
+      app = fastify()
+
+      app.register(fastifyRabbit, {
+        urLs: ['amqp://localhost']
+      })
+
+      app.rabbitmq.connection?.on('connect', function(result) {
+        app.log.debug(result)
+      });
+
+      app.rabbitmq.connection?.on('disconnect', function(err) {
+        app.log.debug(err.stack);
+      });
+    })
+
+    it("create sender",  () => {
+
+      app.rabbitmq.createSender({
+        name: 'foo',
+        options: {
+          durable: true
+        }
+      })
+
+    })
+
+  })
+
+
+
+})

--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -1,6 +1,6 @@
 import {ConsumeMessage} from "amqplib";
 import fastify, {FastifyInstance} from "fastify";
-import {Channel} from "../../node-amqp-connection-manager";
+import {Channel} from "../src";
 import fastifyRabbit from "../src";
 
 describe('fastify-rabbitmq sample app tests',  () => {

--- a/__tests__/rabbitmq.test.ts
+++ b/__tests__/rabbitmq.test.ts
@@ -106,8 +106,6 @@ describe('plugin fastify-rabbitmq tests',  () => {
         expect(app.rabbitmq).toHaveProperty('isConnected');
         expect(app.rabbitmq).toHaveProperty('reconnect');
         expect(app.rabbitmq).toHaveProperty('close');
-        expect(app.rabbitmq.channel).toBeUndefined();
-
       })
 
       await app.rabbitmq.close()
@@ -124,8 +122,6 @@ describe('plugin fastify-rabbitmq tests',  () => {
         expect(app.rabbitmq["unittest"]).toHaveProperty('isConnected');
         expect(app.rabbitmq["unittest"]).toHaveProperty('reconnect');
         expect(app.rabbitmq["unittest"]).toHaveProperty('close');
-        expect(app.rabbitmq.channel).toBeUndefined();
-
       })
 
       await app.rabbitmq["unittest"]?.close()

--- a/__tests__/rabbitmq.test.ts
+++ b/__tests__/rabbitmq.test.ts
@@ -12,9 +12,9 @@ afterEach( () => {
   app.close.bind(app);
 });
 
-describe('fastify-rabbitmq', () => {
+describe('plugin fastify-rabbitmq tests',  () => {
 
-  describe('registration tests', () => {
+  describe('registration tests',  () => {
 
     it("register - error out - no urLs", async () => {
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1-alpha.2",
   "description": "A Fastify RabbitMQ Plugin Developed in Pure TypeScript using the AMQPLIB",
   "type": "module",
-  "types": "index.d.ts",
+  "types": "types/index.d.ts",
   "main": "index.js",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   "dependencies": {
     "@fastify/error": "^3.4.0",
     "amqp-connection-manager": "^4.1.14",
+    "@types/amqplib": "^0.10.3",
     "fastify-plugin": "^4.5.1"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.10.3",
     "@types/jest": "^29.5.7",
     "@types/node": "^20.8.10",
     "@typescript-eslint/parser": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   "homepage": "https://github.com/Bugs5382/fastify-rabbitmq#readme",
   "dependencies": {
     "@fastify/error": "^3.4.0",
-    "amqp-connection-manager": "^4.1.14",
     "@types/amqplib": "^0.10.3",
+    "amqplib": "^0.10.3",
+    "amqp-connection-manager": "^4.1.14",
     "fastify-plugin": "^4.5.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ const decorateFastifyInstance = (fastify: FastifyInstance, options: FastifyRabbi
       ...fastify.rabbitmq,
       [namespace]: connection
     })
-
   } else {
     if (typeof fastify.rabbitmq !== 'undefined') {
       throw new errors.FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS('Already registered.')
@@ -87,7 +86,7 @@ const fastifyRabbit = fp<FastifyRabbitMQOptions>(async (fastify, options, done) 
   /**
    * Decorate Fastify
    */
-  decorateFastifyInstance(fastify, options, {connection})
+  decorateFastifyInstance(fastify, options, { connection })
 
   done()
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import FastifyRabbitMQOptions = fastifyRabbitMQ.FastifyRabbitMQOptions
 
 /**
  * decorateFastifyInstance
- * @since 0.0.1
+ * @since 1.0.0
  * @param fastify
  * @param options
  * @param decorateOptions
@@ -40,6 +40,7 @@ const decorateFastifyInstance = (fastify: FastifyInstance, options: FastifyRabbi
       ...fastify.rabbitmq,
       [namespace]: connection
     })
+
   } else {
     if (typeof fastify.rabbitmq !== 'undefined') {
       throw new errors.FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS('Already registered.')
@@ -83,24 +84,10 @@ const fastifyRabbit = fp<FastifyRabbitMQOptions>(async (fastify, options, done) 
     logger.debug('[fastify-rabbitmq] Connection to RabbitMQ Connection Failed')
   })
 
-  connection.on('disconnect', function () {
-    logger.debug('[fastify-rabbitmq] Connection to RabbitMQ Disconnected')
-  })
-
-  connection.on('blocked', function () {
-    logger.debug('[fastify-rabbitmq] Connection to RabbitMQ Blocked')
-  })
-
-  connection.on('unblocked', function () {
-    logger.debug('[fastify-rabbitmq] Connection to RabbitMQ Un-Blocked')
-  })
-
   /**
    * Decorate Fastify
    */
-  decorateFastifyInstance(fastify, options, {
-    connection
-  })
+  decorateFastifyInstance(fastify, options, {connection})
 
   done()
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,11 @@
 import { Channel, ConfirmChannel } from 'amqplib'
-import amqp, {
-  AmqpConnectionManager,
-  AmqpConnectionManagerOptions,
-  ChannelWrapper,
-  ConnectionUrl
-} from 'amqp-connection-manager'
+import amqp from 'amqp-connection-manager'
 import { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
+import { fastifyRabbitMQ } from '../types'
 import { errors } from './errors'
 import { validateOpts } from './validation'
-
 import FastifyRabbitMQOptions = fastifyRabbitMQ.FastifyRabbitMQOptions
-import FastifyRabbitMQObject = fastifyRabbitMQ.FastifyRabbitMQObject
-
-declare module 'fastify' {
-
-  interface FastifyInstance {
-    rabbitmq: FastifyRabbitMQObject & fastifyRabbitMQ.FastifyRabbitMQNestedObject
-  }
-
-}
-
-declare namespace fastifyRabbitMQ {
-
-  export interface FastifyRabbitMQObject extends AmqpConnectionManager {
-    channel?: ChannelWrapper
-  }
-
-  export interface FastifyRabbitMQNestedObject {
-    [namespace: string]: FastifyRabbitMQObject
-  }
-
-  export type FastifyRabbitMQOptions = AmqpConnectionManagerOptions & {
-    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
-    namespace?: string
-    urLs: ConnectionUrl | ConnectionUrl[] | undefined | null
-  }
-
-}
 
 /**
  * decorateFastifyInstance

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,28 @@
 {
-  "files": [
-    "src/index.ts"
-  ],
+  "compileOnSave": true,
   "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
     "target": "es2015",
     "module": "es2015",
     "moduleResolution": "node",
     "declaration": true,
-    "outDir": "./dist",
-    "noEmit": false,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "allowUnreachableCode": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitAny": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "strictNullChecks": true,
+    "types": ["jest", "node"]
   },
+  "include": [
+    "./**/*"
+  ],
   "exclude": [
     "node_modules",
+    "jest.config.ts",
+    "./__tests__/**/*",
+    "./coverage/**/*",
+    "./types/**/*",
+    "./dist/**/*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
     "skipLibCheck": true
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
   ]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,4 @@
-import { ChannelWrapper, ConnectionUrl } from 'amqp-connection-manager'
-import { IAmqpConnectionManager } from 'amqp-connection-manager/dist/types/AmqpConnectionManager'
+import { AmqpConnectionManager, ConnectionUrl } from 'amqp-connection-manager'
 import { FastifyPluginAsync, FastifyPluginOptions } from 'fastify'
 
 declare module 'fastify' {
@@ -8,7 +7,7 @@ declare module 'fastify' {
     /**
      * RabbitMQ Connection
      */
-    rabbitmq: IAmqpConnectionManager & fastifyRabbitMQ.FastifyRabbitMQAmqpNestedObject
+    rabbitmq: AmqpConnectionManager & fastifyRabbitMQ.FastifyRabbitMQAmqpNestedObject
   }
 
 }
@@ -17,23 +16,11 @@ type FastifyRabbitMQ = FastifyPluginAsync<fastifyRabbitMQ.FastifyRabbitMQOptions
 
 declare namespace fastifyRabbitMQ {
 
-  export interface FastifyRabbitMQChannelProperties {
-    /* Name of the Channel */
-    name: string
-    /* RabbitMQ Options for Channel */
-    options: any
-  }
-
-  export interface FastifyRabbitMQChannels extends FastifyRabbitMQChannelProperties {
-    /* The channel wrapper from amqp-connection-manager */
-    channel: ChannelWrapper
-  }
-
   export interface FastifyRabbitMQAmqpNestedObject {
     /**
      * Nested Namespace
      */
-    [namespace: string]: IAmqpConnectionManager
+    [namespace: string]: AmqpConnectionManager
   }
 
   export interface FastifyRabbitMQOptions extends FastifyPluginOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,56 @@
+import { AmqpConnectionManager, ChannelWrapper, ConnectionUrl } from 'amqp-connection-manager'
+import { FastifyPluginAsync, FastifyPluginOptions } from 'fastify'
+
+export interface FastifyRabbitMQCreateSender {
+  /* Name of the Channel */
+  name: string
+  /* RabbitMQ Options for Sending */
+  options: any
+}
+
+declare module 'fastify' {
+
+  interface FastifyInstance {
+    rabbitmq: fastifyRabbitMQ.FastifyRabbitMQObject & fastifyRabbitMQ.FastifyRabbitMQNestedObject
+  }
+
+}
+
+type FastifyRabbitMQ = FastifyPluginAsync<fastifyRabbitMQ.FastifyRabbitMQOptions>
+
+declare namespace fastifyRabbitMQ {
+
+  export interface FastifyRabbitMQObject extends AmqpConnectionManager {
+    /**
+     * Create a sender channel
+     */
+    createSender: (opts: FastifyRabbitMQCreateSender) => void
+    /**
+     * Get wrapper channel
+     */
+    getSendChannel: (name: string) => ChannelWrapper
+  }
+
+  export interface FastifyRabbitMQNestedObject {
+    /**
+     * Nested Namespace
+     */
+    [namespace: string]: FastifyRabbitMQObject
+  }
+
+  export interface FastifyRabbitMQOptions extends FastifyPluginOptions {
+    /**
+     * Log Level for RabbitMQ Debugging
+     */
+    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
+    /**
+     * Namespace
+     */
+    namespace?: string
+    /**
+     * Connection URLS for AmqpConnectionManager
+     */
+    urLs: ConnectionUrl | ConnectionUrl[] | undefined | null
+  }
+
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,17 +1,14 @@
-import { AmqpConnectionManager, ChannelWrapper, ConnectionUrl } from 'amqp-connection-manager'
+import { ChannelWrapper, ConnectionUrl } from 'amqp-connection-manager'
+import { IAmqpConnectionManager } from 'amqp-connection-manager/dist/types/AmqpConnectionManager'
 import { FastifyPluginAsync, FastifyPluginOptions } from 'fastify'
-
-export interface FastifyRabbitMQCreateSender {
-  /* Name of the Channel */
-  name: string
-  /* RabbitMQ Options for Sending */
-  options: any
-}
 
 declare module 'fastify' {
 
   interface FastifyInstance {
-    rabbitmq: fastifyRabbitMQ.FastifyRabbitMQObject & fastifyRabbitMQ.FastifyRabbitMQNestedObject
+    /**
+     * RabbitMQ Connection
+     */
+    rabbitmq: IAmqpConnectionManager & fastifyRabbitMQ.FastifyRabbitMQAmqpNestedObject
   }
 
 }
@@ -20,22 +17,23 @@ type FastifyRabbitMQ = FastifyPluginAsync<fastifyRabbitMQ.FastifyRabbitMQOptions
 
 declare namespace fastifyRabbitMQ {
 
-  export interface FastifyRabbitMQObject extends AmqpConnectionManager {
-    /**
-     * Create a sender channel
-     */
-    createSender: (opts: FastifyRabbitMQCreateSender) => void
-    /**
-     * Get wrapper channel
-     */
-    getSendChannel: (name: string) => ChannelWrapper
+  export interface FastifyRabbitMQChannelProperties {
+    /* Name of the Channel */
+    name: string
+    /* RabbitMQ Options for Channel */
+    options: any
   }
 
-  export interface FastifyRabbitMQNestedObject {
+  export interface FastifyRabbitMQChannels extends FastifyRabbitMQChannelProperties {
+    /* The channel wrapper from amqp-connection-manager */
+    channel: ChannelWrapper
+  }
+
+  export interface FastifyRabbitMQAmqpNestedObject {
     /**
      * Nested Namespace
      */
-    [namespace: string]: FastifyRabbitMQObject
+    [namespace: string]: IAmqpConnectionManager
   }
 
   export interface FastifyRabbitMQOptions extends FastifyPluginOptions {


### PR DESCRIPTION
Will allow the user to create "sender" and "receiver" channels in a simplified fashion.
 Also will:
* Allow more than ne channel for an app.
* Enable users to use RabbitMQ in a Reply and/or Request functions so