### PR TITLE
docs: rewrite README to standard, add AGENTS.md, fix typedoc parent-export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md - fastify-rabbitmq
+
+Guide for AI agents working in this repo. Pair with `CLAUDE.md` (the working agreement and
+hook-enforced rules). Keep this file current when the build, layout, or public API changes.
+
+## What this is
+
+A Fastify plugin (built on `fastify-plugin`) that wraps the
+[`rabbitmq-client`](https://www.npmjs.com/package/rabbitmq-client) package so a Fastify app can
+publish, consume, and RPC over RabbitMQ (AMQP 0-9-1). The plugin decorates the Fastify instance with
+`app.rabbitmq` — a live `rabbitmq-client` `Connection` — and supports multiple named connections.
+
+Published to npm as `fastify-rabbitmq`. Ships dual ESM + CJS with type declarations.
+
+## Using fastify-rabbitmq in an app
+
+If you are an agent wiring this plugin into a Fastify app (not editing this repo), start from the
+[README](./README.md) — it has recipes for publish, consume, RPC, topology declaration, and
+namespaces. The contract to respect:
+
+- **Single entry point.** Register the plugin (`await app.register(fastifyRabbitMQ, opts)`) and use
+  the `app.rabbitmq` decorator. Do not import `rabbitmq-client` directly in app code.
+- **`app.rabbitmq` is the full Connection.** It exposes the underlying `rabbitmq-client` `Connection`
+  API directly (`createPublisher`, `createConsumer`, `createRPCClient`, `exchangeDeclare`,
+  `queueDeclare`, `queueBind`, `acquire`, `ready`, `close`) — nothing is wrapped away.
+- **`connection` is required** — a connection string or a `rabbitmq-client` `ConnectionOptions`.
+- **Namespaces for multiple brokers.** Register once per unique `namespace`; reach each at
+  `app.rabbitmq.<namespace>`. Re-using a namespace throws `FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS`.
+- In a route, reach the instance via `request.server.rabbitmq`.
+
+## Layout
+
+- `src/index.ts` - plugin entry; registered through `fastify-plugin`, decorates the instance with the
+  `rabbitmq-client` `Connection` (per namespace).
+- `src/decorate.ts` - the `FastifyRabbitMQOptions` interface (`connection`, `namespace`).
+- `src/types.ts` - the Fastify augmentation (`declare module "fastify"`) exposing `rabbitmq`.
+- `src/validation.ts` - plugin option validation.
+- `src/errors.ts` - `@fastify/error` definitions.
+- `__tests__/` - vitest suite; the integration tests connect to a real broker.
+
+## Build, test, lint
+
+- Build: `npm run build` (tsdown -> ESM+CJS in `dist/`; types via `tsc --emitDeclarationOnly`).
+- Test: `npm test` (vitest). The **integration tests need a running RabbitMQ broker** at
+  `RABBITMQ_URL` (default `amqp://guest:guest@localhost`); CI provides one via a `rabbitmq` service.
+  The unit/registration tests run without a broker.
+- Lint: `npm run lint` (the shared `@the-rabbit-hole/eslint-config`); `npm run lint:fix` to autofix.
+- License headers: `task license` verifies the MIT header (CI); `task license:fix` injects it.
+- Docs: `npm run typedoc`.
+
+## Conventions and gotchas
+
+- The plugin is the only public entry point. Construct RabbitMQ objects through `app.rabbitmq`, not by
+  importing `rabbitmq-client` directly in app code.
+- Integration tests require a broker — run one locally (`docker run -p 5672:5672 rabbitmq:4-alpine`)
+  or rely on CI's `rabbitmq` service; without it, the integration tests time out.
+- See `CLAUDE.md` for branch/commit/PR rules; these are enforced by the git hooks in `.claude/hooks`.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,188 @@
-# Fastify RabbitMQ
+# 🐰 Fastify RabbitMQ
 
-A Fastify RabbitMQ Plugin Developed in Pure TypeScript.
-It uses the [node-rabbitmq-client](https://github.com/cody-greene/node-rabbitmq-client/) plugin as a wrapper.
+A Fastify RabbitMQ plugin developed in pure TypeScript.
+It wraps the [`rabbitmq-client`](https://www.npmjs.com/package/rabbitmq-client) package so a Fastify
+app can publish, consume, and RPC over RabbitMQ (AMQP 0-9-1).
 
-The build exports this to valid ESM and CJS for ease of cross-compatibility.
+The build exports valid ESM and CJS for cross-compatibility.
 
-If you are using this NPM package, please consider giving it a :star: star.
-This will increase its visibility and solicit more contribution from the outside.
+If you use this package, please consider giving it a ⭐ — it raises visibility and brings in more
+contribution from the outside.
+
+> This documentation covers **how to use the plugin**. The decorator `app.rabbitmq` is a live
+> `rabbitmq-client` `Connection`, so its full API is available — for publisher/consumer/RPC option
+> details, see [External Libraries](#-external-libraries).
+
+> 🟢 **Requires Node.js ≥ 20.15.**
 
 ## Table of Contents
 
-1. [Install](#install)
-2. [Basic Usage](#basic-usage)
-3. [Full Documentation](#full-documentation)
-   1. [Options](#options)
-4. [Acknowledgements](#acknowledgements)
-5. [License](#license)
+1. [Install](#-install)
+2. [Basic Usage](#-basic-usage)
+3. [Recipes](#-recipes)
+   1. [Publish a message](#1-publish-a-message)
+   2. [Consume a queue](#2-consume-a-queue)
+   3. [RPC (request/response)](#3-rpc-requestresponse)
+   4. [Declare exchanges, queues, and bindings](#4-declare-exchanges-queues-and-bindings)
+   5. [Multiple connections with namespaces](#5-multiple-connections-with-namespaces)
+4. [API Reference](#-api-reference-fastifyrabbitmq)
+5. [Plugin Options](#-plugin-options)
+6. [External Libraries](#-external-libraries)
+7. [Acknowledgements](#-acknowledgements)
+8. [License](#-license)
 
-## Install
+## 📦 Install
 
-```
+```shell
 npm install fastify-rabbitmq
 ```
 
-## Basic Usage
+Requires Node.js ≥ 20.15.
 
-Register this as a plugin.
-Make sure it is loaded before any **_routes_** are loaded.
+## 🚀 Basic Usage
 
-### Quick Setup on the Server Side
+Register the plugin (before any routes that use it):
 
-```typescript
-export default fp<FastifyRabbitMQOptions>((fastify, options, done) => {
-  void fastify.register(fastifyRabbit, {
-    connection: `amqp://guest:guest@localhost`,
-  });
+```ts
+import fastify from "fastify";
+import fastifyRabbitMQ from "fastify-rabbitmq";
 
-  void fastify.ready().then(async () => {
-    const consumer = fastify.rabbitmq.createConsumer(
-      {
-        queue: "foo",
-        queueOptions: { durable: true },
-      },
-      async (msg: any) => {
-        console.log(msg); // ==> bar
-      },
-    );
-  });
+const app = fastify();
+
+await app.register(fastifyRabbitMQ, {
+  connection: "amqp://guest:guest@localhost",
 });
 ```
 
-### Quick Setup on the Client Side
+Registering decorates the Fastify instance with `app.rabbitmq` — a live `rabbitmq-client`
+`Connection`. Use it to create publishers, consumers, and RPC clients, or to declare topology.
 
-Within any "endpoint" function, or if you have access to `fastify.rabbitmq` you can then call:
+## 🧩 Recipes
 
-```js
-fastify.get("/rabbitmq", async (request, reply) => {
-  let pub = request.rabbitmq.createPublisher({
-    confirm: true,
-    maxAttempts: 1,
-  });
+### 1. Publish a message
 
-  await pub.send("foo", "bar"); // ==> sent to foo queue
+```ts
+const publisher = app.rabbitmq.createPublisher({
+  confirm: true,
+  maxAttempts: 1,
+});
+
+await publisher.send("foo", "bar"); // routing key "foo", body "bar"
+```
+
+In a route, reach the instance via `request.server`:
+
+```ts
+app.get("/publish", async (request, reply) => {
+  const publisher = request.server.rabbitmq.createPublisher({ confirm: true });
+  await publisher.send("foo", "bar");
+  return { sent: true };
 });
 ```
 
-Sending the string `bar` to the queue called `foo`.
+### 2. Consume a queue
 
-## Full Documentation
-
-### Options
-
-```typescript
-export interface FastifyRabbitMQOptions {
-  /** Connection String or object pointing to the RabbitMQ Broker Services */
-  connection: string | ConnectionOptions;
-  /** To set the custom nNamespace within this plugin instance. Used to register this plugin more than one time. */
-  namespace?: string;
-}
+```ts
+const consumer = app.rabbitmq.createConsumer(
+  {
+    queue: "foo",
+    queueOptions: { durable: true },
+  },
+  async (msg) => {
+    app.log.info({ body: msg.body }, "received");
+    // ...handle the message...
+  },
+);
 ```
 
-#### FastifyRabbitMQOptions
+### 3. RPC (request/response)
 
-##### `connection`
+```ts
+const rpc = app.rabbitmq.createRPCClient({ confirm: true });
+const response = await rpc.send("my-rpc-queue", "ping");
+app.log.info({ response: response.body }, "rpc reply");
+```
 
-Connection String or object pointing to the RabbitMQ Broker Services.
-This can be an object of `ConnectionOptions` from the `node-rabbitmq-client` plugin options.
+### 4. Declare exchanges, queues, and bindings
 
-##### `namespace`
+```ts
+await app.rabbitmq.queueDeclare({ queue: "foo", durable: true });
+await app.rabbitmq.exchangeDeclare({ exchange: "my-exchange", type: "topic" });
+await app.rabbitmq.queueBind({
+  queue: "foo",
+  exchange: "my-exchange",
+  routingKey: "foo.#",
+});
+```
 
-If you need more than one "connection" to a different set and/or array of RabbitMQ servers,
-either on network or cloud, each registration of the plugin needs it to be in its own namespace.
-If the name space is duplicated, it will fail to load.
+### 5. Multiple connections with namespaces
 
-## Acknowledgements
+To talk to more than one broker (or keep separate connections), register the plugin once per
+`namespace`; each is reachable at `app.rabbitmq.<namespace>`:
 
-- [node-rabbitmq-client](https://www.npmjs.com/package/rabbitmq-client)
-- [fastify](https://fastify.dev/)
-- ... and my Wife and Baby Girl.
+```ts
+await app.register(fastifyRabbitMQ, {
+  connection: "amqp://guest:guest@broker-a",
+  namespace: "a",
+});
+await app.register(fastifyRabbitMQ, {
+  connection: "amqp://guest:guest@broker-b",
+  namespace: "b",
+});
 
-## License
+const pubA = app.rabbitmq.a.createPublisher();
+const pubB = app.rabbitmq.b.createPublisher();
+```
+
+Registering the same namespace twice throws `FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS`.
+
+## 📖 API Reference (`fastify.rabbitmq`)
+
+`app.rabbitmq` is a `rabbitmq-client` `Connection` (and, with namespaces, an index of them). The
+methods you will use most:
+
+| Method | Description |
+|---|---|
+| `createPublisher(options?)` | Create a `Publisher` (`.send(routingKey, body)`). |
+| `createConsumer(options, handler)` | Create a `Consumer` bound to a queue; `handler(msg)` runs per message. |
+| `createRPCClient(options?)` | Create an RPC client (`.send(queue, body)` returns the reply). |
+| `exchangeDeclare(params)` | Declare an exchange. |
+| `queueDeclare(params)` | Declare a queue. |
+| `queueBind(params)` | Bind a queue to an exchange. |
+| `acquire()` | Acquire a raw channel. |
+| `ready()` | Resolve once the connection is established. |
+| `close()` | Close the connection. |
+
+The full option shapes for each come from `rabbitmq-client` — see [External Libraries](#-external-libraries).
+
+## ⚙️ Plugin Options
+
+Pass these to `app.register(fastifyRabbitMQ, options)`:
+
+### `connection`
+
+A connection string (e.g. `"amqp://guest:guest@localhost"`) or a `ConnectionOptions` object from
+`rabbitmq-client` pointing at the broker. **Required.**
+
+### `namespace`
+
+`string` — register the plugin more than once by giving each instance a unique namespace; the
+connection is then exposed at `app.rabbitmq.<namespace>`. Re-using a namespace fails to load.
+
+## 🔌 External Libraries
+
+This plugin documents only its own surface. For publisher/consumer/RPC options, connection options
+(`ConnectionOptions`), TLS, and reconnect behavior, see the package it wraps:
+
+- [`rabbitmq-client`](https://www.npmjs.com/package/rabbitmq-client) — the underlying AMQP client
+  (repo: [cody-greene/node-rabbitmq-client](https://github.com/cody-greene/node-rabbitmq-client)).
+
+## 🙏 Acknowledgements
+
+- [`rabbitmq-client`](https://www.npmjs.com/package/rabbitmq-client)
+- [Fastify](https://fastify.dev/)
+- ...and my Wife and Baby Girl.
+
+## 📄 License
 
 Licensed under [MIT](./LICENSE).

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,12 +1,21 @@
 {
-  "tsconfig": "src/tsconfig.esm.json",
-  "entryPoints": ["./src/index.ts"],
+  "tsconfig": "tsconfig.json",
+  "entryPoints": [
+    "./src/index.ts"
+  ],
   "githubPages": false,
   "includeVersion": true,
-  "plugin": ["@shipgirl/typedoc-plugin-versions"],
+  "plugin": [
+    "@shipgirl/typedoc-plugin-versions"
+  ],
   "out": "docs",
   "name": "Fastify RabbitMQ",
   "sidebarLinks": {
     "View source on GitHub": "https://github.com/Bugs5382/fastify-rabbitmq"
+  },
+  "externalSymbolLinkMappings": {
+    "rabbitmq-client": {
+      "*": "https://www.npmjs.com/package/rabbitmq-client"
+    }
   }
 }


### PR DESCRIPTION
## What
Phase 4 (#115, parent #117): docs to the standard.
- **README** rewritten to the fastify-hl7 standard: install, recipes (publish, consume, RPC, declare topology, namespaces), the `app.rabbitmq` API reference, plugin options, an External Libraries link to `rabbitmq-client`, and the Node >= 20.15 note. Corrected the stale `node-rabbitmq-client` naming.
- **AGENTS.md** added (contributor + "using this plugin in an app" guide).
- **typedoc** (#109): fixed the stale `src/tsconfig.esm.json` reference (-> `tsconfig.json`) and added `externalSymbolLinkMappings` so re-exported `rabbitmq-client` symbols link to their docs instead of rendering as undocumented references. typedoc now builds clean.

## Verification
- `npm run typedoc` builds with no "referenced but not included" warnings.

Closes #115
Closes #109