### PR TITLE
fix: validate connection shape and reject invalid registration options

### DIFF
--- a/__tests__/rabbitmq.test.ts
+++ b/__tests__/rabbitmq.test.ts
@@ -24,7 +24,6 @@ import fastify, { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import fastifyRabbit from "../src";
-import { errors } from "../src/errors";
 
 let app: FastifyInstance;
 
@@ -102,21 +101,20 @@ describe("plugin fastify-rabbitmq tests", () => {
 
   describe("duplicate registration", () => {
     test("rejects a second registration without a namespace", async () => {
-      await app.register(fastifyRabbit, { connection: RABBITMQ_URL });
-      await app.register(fastifyRabbit, { connection: RABBITMQ_URL });
+      // Queue both registrations; the duplicate is detected when the app boots,
+      // so the rejection surfaces from ready(), not from register().
+      app.register(fastifyRabbit, { connection: RABBITMQ_URL });
+      app.register(fastifyRabbit, { connection: RABBITMQ_URL });
 
-      await expect(app.ready()).rejects.toThrow(
-        new errors.FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS("Already registered.")
-          .message,
-      );
+      await expect(app.ready()).rejects.toThrow("Already registered.");
     });
 
     test("rejects re-using a namespace", async () => {
-      await app.register(fastifyRabbit, {
+      app.register(fastifyRabbit, {
         connection: RABBITMQ_URL,
         namespace: "error",
       });
-      await app.register(fastifyRabbit, {
+      app.register(fastifyRabbit, {
         connection: RABBITMQ_URL,
         namespace: "error",
       });

--- a/__tests__/rabbitmq.test.ts
+++ b/__tests__/rabbitmq.test.ts
@@ -38,183 +38,119 @@ afterEach(async () => {
   await app.close();
 });
 
+const DECORATED_METHODS = [
+  "acquire",
+  "close",
+  "createConsumer",
+  "createPublisher",
+  "createRPCClient",
+  "exchangeDeclare",
+  "queueDeclare",
+  "queueBind",
+  "ready",
+];
+
 describe("plugin fastify-rabbitmq tests", () => {
-  describe("registration tests", () => {
-    test("register - error out - no urls", async () => {
-      try {
+  describe("option validation", () => {
+    test("rejects a missing options object", async () => {
+      await expect(
         // @ts-expect-error registering with no options is a type error; this exercises the runtime validation.
-        await app.register(fastifyRabbit);
-      } catch (error) {
-        expect(error).toEqual(
-          new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
-            "connection or findServers must be defined.",
-          ),
-        );
-      }
+        app.register(fastifyRabbit).ready(),
+      ).rejects.toThrow("connection must be defined.");
     });
 
-    test("register - error out - connection not defined", async () => {
-      try {
+    test("rejects an undefined connection", async () => {
+      await expect(
         // @ts-expect-error connection: undefined is not assignable; this exercises the runtime guard.
-        await app.register(fastifyRabbit, { connection: undefined });
-      } catch (error) {
-        expect(error).toEqual(
-          new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
-            "connection or findServers must be defined.",
-          ),
-        );
-      }
+        app.register(fastifyRabbit, { connection: undefined }).ready(),
+      ).rejects.toThrow("connection must be defined.");
     });
 
-    test("register - error out - urls is not a string", async () => {
-      try {
+    test("rejects an empty connection string", async () => {
+      await expect(
+        app.register(fastifyRabbit, { connection: "" }).ready(),
+      ).rejects.toThrow("connection string must not be empty.");
+    });
+
+    test("rejects a non-string, non-object connection (number)", async () => {
+      await expect(
         // @ts-expect-error connection: 1 (a number) is not a valid type; this exercises the runtime validation.
-        await app.register(fastifyRabbit, {
-          connection: 1,
-        });
-      } catch (error) {
-        expect(error).toEqual(
-          new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
-            "urls must be defined.",
-          ),
-        );
-      }
+        app.register(fastifyRabbit, { connection: 1 }).ready(),
+      ).rejects.toThrow(
+        "connection must be a connection string or a ConnectionOptions object.",
+      );
     });
 
-    test("register - error out - urls less than 0", async () => {
-      try {
+    test("rejects an array connection", async () => {
+      await expect(
         // @ts-expect-error connection: [] (an array) is not a valid type; this exercises the runtime validation.
-        await app.register(fastifyRabbit, {
-          connection: [],
-        });
-      } catch (error) {
-        expect(error).toEqual(
-          new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
-            "urls must contain one or more item in the array.",
-          ),
-        );
-      }
+        app.register(fastifyRabbit, { connection: [] }).ready(),
+      ).rejects.toThrow(
+        "connection must be a connection string or a ConnectionOptions object.",
+      );
+    });
+
+    test("rejects a null connection", async () => {
+      await expect(
+        // @ts-expect-error connection: null is not a valid type; this exercises the runtime validation.
+        app.register(fastifyRabbit, { connection: null }).ready(), // eslint-disable-line unicorn/no-null -- exercising the guard against a null connection
+      ).rejects.toThrow(
+        "connection must be a connection string or a ConnectionOptions object.",
+      );
     });
   });
 
-  describe("sanity checks", () => {
-    test("register - can't be registered twice", async () => {
-      try {
-        await app.register(fastifyRabbit, {
-          connection: RABBITMQ_URL,
-        });
+  describe("duplicate registration", () => {
+    test("rejects a second registration without a namespace", async () => {
+      await app.register(fastifyRabbit, { connection: RABBITMQ_URL });
+      await app.register(fastifyRabbit, { connection: RABBITMQ_URL });
 
-        await app.register(fastifyRabbit, {
-          connection: RABBITMQ_URL,
-        });
-      } catch (error) {
-        expect(error).toEqual(
-          new errors.FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS("Already registered."),
-        );
-      }
+      await expect(app.ready()).rejects.toThrow(
+        new errors.FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS("Already registered.")
+          .message,
+      );
     });
 
-    test("register - can't be registered twice - namespace", async () => {
-      try {
-        await app.register(fastifyRabbit, {
-          connection: RABBITMQ_URL,
-          namespace: "error",
-        });
+    test("rejects re-using a namespace", async () => {
+      await app.register(fastifyRabbit, {
+        connection: RABBITMQ_URL,
+        namespace: "error",
+      });
+      await app.register(fastifyRabbit, {
+        connection: RABBITMQ_URL,
+        namespace: "error",
+      });
 
-        await app.register(fastifyRabbit, {
-          connection: RABBITMQ_URL,
-          namespace: "error",
-        });
-      } catch (error) {
-        expect(error).toEqual(
-          new errors.FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS(
-            "Already registered with namespace: error",
-          ),
-        );
-      }
+      await expect(app.ready()).rejects.toThrow(
+        "Already registered with namespace: error",
+      );
     });
   });
 
-  describe("common action tests", () => {
-    test("ensure basic properties are accessible", async () => {
-      try {
-        await app.register(fastifyRabbit, {
-          connection: "amqp://guest:guest@localhost",
-        });
-        expect(app.rabbitmq).toHaveProperty("acquire");
-        expect(app.rabbitmq).toHaveProperty("close");
-        expect(app.rabbitmq).toHaveProperty("createConsumer");
-        expect(app.rabbitmq).toHaveProperty("createPublisher");
-        expect(app.rabbitmq).toHaveProperty("createRPCClient");
-        expect(app.rabbitmq).toHaveProperty("exchangeDeclare");
-        expect(app.rabbitmq).toHaveProperty("queueDeclare");
-        expect(app.rabbitmq).toHaveProperty("queueBind");
-        expect(app.rabbitmq).toHaveProperty("ready");
+  describe("decorator", () => {
+    test("exposes the rabbitmq-client Connection on app.rabbitmq", async () => {
+      await app.register(fastifyRabbit, { connection: RABBITMQ_URL }).ready();
 
-        await app.rabbitmq.close();
-      } catch {
-        /* should not error */
+      for (const method of DECORATED_METHODS) {
+        expect(app.rabbitmq).toHaveProperty(method);
       }
+
+      await app.rabbitmq.close();
     });
 
-    test("ensure basic properties are accessible via namespace", async () => {
-      try {
-        await app
-          .register(fastifyRabbit, {
-            connection: RABBITMQ_URL,
-            namespace: "unittest",
-          })
-          .ready()
-          .then(async () => {
-            expect(app.rabbitmq.unittest).toHaveProperty("acquire");
-            expect(app.rabbitmq.unittest).toHaveProperty("close");
-            expect(app.rabbitmq.unittest).toHaveProperty("createConsumer");
-            expect(app.rabbitmq.unittest).toHaveProperty("createPublisher");
-            expect(app.rabbitmq.unittest).toHaveProperty("createRPCClient");
-            expect(app.rabbitmq.unittest).toHaveProperty("exchangeDeclare");
-            expect(app.rabbitmq.unittest).toHaveProperty("queueDeclare");
-            expect(app.rabbitmq.unittest).toHaveProperty("queueBind");
-            expect(app.rabbitmq.unittest).toHaveProperty("ready");
-          });
+    test("exposes the Connection under app.rabbitmq.<namespace>", async () => {
+      await app
+        .register(fastifyRabbit, {
+          connection: RABBITMQ_URL,
+          namespace: "unittest",
+        })
+        .ready();
 
-        await app.rabbitmq.unittest.close();
-      } catch {
-        /* should not error */
+      for (const method of DECORATED_METHODS) {
+        expect(app.rabbitmq.unittest).toHaveProperty(method);
       }
-    });
 
-    test("register with log level: debug", async () => {
-      try {
-        await app
-          .register(fastifyRabbit, {
-            connection: RABBITMQ_URL,
-            logLevel: "debug",
-          })
-          .ready()
-          .then(async () => {
-            expect(app.rabbitmq.unittest).toHaveProperty("createConsumer");
-            await app.rabbitmq.close();
-          });
-      } catch {
-        /* should not error */
-      }
-    });
-
-    test("register with log level: trace", async () => {
-      try {
-        await app
-          .register(fastifyRabbit, {
-            connection: RABBITMQ_URL,
-            logLevel: "trace",
-          })
-          .ready()
-          .then(async () => {
-            expect(app.rabbitmq.unittest).toHaveProperty("createConsumer");
-            await app.rabbitmq.close();
-          });
-      } catch {
-        /* should not error */
-      }
+      await app.rabbitmq.unittest.close();
     });
   });
 });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -25,24 +25,46 @@ import { errors } from "./errors";
 
 /**
  * Validate Options
+ *
+ * The plugin validates only the *shape* of `connection` -- that it is a
+ * non-empty connection string or a `ConnectionOptions` object. Parsing the URL
+ * and validating the broker options (hosts, TLS, reconnect, etc.) is delegated
+ * to `rabbitmq-client`. The shape guard exists because `new Connection(...)`
+ * accepts garbage (a number, an array, `null`, `{}`) without throwing and then
+ * silently fails to connect at runtime; rejecting it here surfaces a clear
+ * registration-time error instead.
  * @since 1.0.0
  * @param options
  */
 export const validateOpts = async (
   options: FastifyRabbitMQOptions,
 ): Promise<void> => {
+  const { connection } = options;
+
   // Mandatory
-  if (options.connection === undefined) {
+  if (connection === undefined) {
     throw new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
-      "connection or findServers must be defined.",
+      "connection must be defined.",
     );
   }
 
-  // Mandatory
-  if (
-    options.connection !== undefined &&
-    typeof options.connection !== "object"
-  ) {
-    // we need to do some sort of check here to make sure RabbitMQOptions is "valid"
+  if (typeof connection === "string") {
+    if (connection.length === 0) {
+      throw new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
+        "connection string must not be empty.",
+      );
+    }
+    return;
+  }
+
+  const isConnectionOptions =
+    typeof connection === "object" &&
+    connection !== null &&
+    !Array.isArray(connection);
+
+  if (!isConnectionOptions) {
+    throw new errors.FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS(
+      "connection must be a connection string or a ConnectionOptions object.",
+    );
   }
 };


### PR DESCRIPTION
## What and why

Phase 3 review of the wrapper surface (`decorate.ts`, the hook, `validation.ts`, `errors.ts`, `types.ts`). The review found **no under-exposed-capability gap** — `app.rabbitmq` is the full `rabbitmq-client` `Connection`. It did find a real validation hole:

`validateOpts` only rejected an undefined `connection`; its second branch was an empty TODO. A number, array, `null`, empty string, or any other non-string/non-object value passed validation. `new Connection(...)` accepts all of those silently and only fails to connect later, so misconfiguration surfaced as a cryptic runtime error instead of a clear one at registration.

This adds a **shape guard**: `connection` must be a non-empty connection string or a `ConnectionOptions` object, otherwise `FASTIFY_RABBIT_MQ_ERR_INVALID_OPTS` is thrown with a specific message. The boundary is deliberate — parsing the URL and validating broker options (hosts, TLS, reconnect) stays with `rabbitmq-client`; the plugin only guards the shape it is handed.

The old `connection: 1` / `connection: []` tests asserted messages about "urls" — a removed API — and their `expect` lived inside a `catch` that never ran, so they were vacuous. They are rewritten to assert rejection with `.rejects.toThrow`, and the decorator / duplicate-registration tests are tightened (no more swallowed errors; the bogus `logLevel` cases, which referenced an option that does not exist, are removed).

## Closes

Closes #114

## Verification

- `npm run lint` clean.
- `npm run build` succeeds (tsdown + `tsc --emitDeclarationOnly`).
- The six option-validation cases pass locally (undefined, missing options, empty string, number, array, null). The decorator and duplicate-registration tests need a broker and run against CI's `rabbitmq` service.

## Closing summary

Validation now fails fast with a clear, namespaced error for malformed `connection` options, and the unit suite asserts that behavior instead of dead code paths. No public API change beyond stricter registration-time rejection.