### PR TITLE
ci: reconcile publish, deploy, and test workflows to the OIDC standard

### DIFF
--- a/.github/workflows/action-deploy.yaml
+++ b/.github/workflows/action-deploy.yaml
@@ -1,4 +1,9 @@
 name: Release and Publish
+# Fires when the maintainer publishes a (stable) GitHub Release. By then the
+# Release Manager (job-version-bump.yaml) has already bumped package.json and
+# written CHANGELOG.md on main, so this only re-tests, publishes to npm via
+# OIDC, and republishes the docs. Stable-only: prereleases are not shipped, and
+# there is no manual-dispatch path that could publish off a release.
 on:
   release:
     types:
@@ -6,104 +11,53 @@ on:
 
 permissions:
   contents: write
-  actions: write
-  checks: write
   id-token: write
 
 jobs:
   Test:
+    name: 🧪 Test
     uses: ./.github/workflows/action-test.yaml
 
-  Strip_Version:
-    runs-on: ubuntu-latest
-    outputs:
-      CLEAN_TAG: ${{ steps.set-output.outputs.CLEAN_TAG }}
-    steps:
-      - name: Strip "v" from Tag
-        id: set-output
-        run: echo "CLEAN_TAG=${GITHUB_EVENT_RELEASE_TAG_NAME#v}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
-
   Publish:
+    name: 🚀 Publish
     runs-on: ubuntu-latest
-    outputs:
-      GIT_BRANCH_TARGET: ${{ steps.set-npm-tag.outputs.GIT_BRANCH_TARGET }}
-    needs: ['Test', 'Strip_Version']
-    env:
-      CLEAN_TAG: ${{ needs.Strip_Version.outputs.CLEAN_TAG }}
+    needs: [Test]
+    # id-token: write lets npm verify the OIDC token GitHub issues against the
+    # trusted publisher registered on npmjs.com -- no NPM_TOKEN.
     steps:
-      - name: Create Directory
-        run: mkdir -p ./lib
-
       - name: Download the build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: cache
+          name: dist
           path: ./
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Update Version in Package.json
-        id: set-npm-tag
+      # OIDC trusted publishing + provenance require npm >= 11.5.1 (the LTS image
+      # ships 10.x).
+      - name: Upgrade npm
         run: |
-          npm version $CLEAN_TAG --no-git-tag-version
-          if [[ "$CLEAN_TAG" == *"beta"* ]]; then
-            echo "NPM_TAG=beta" >> $GITHUB_OUTPUT
-            echo "GIT_BRANCH_TARGET=develop" >> $GITHUB_OUTPUT
+          npm install -g npm@latest
+          npm --version
+
+      # The version is already in package.json (set by the Release Manager).
+      # Idempotent: skip if that exact version is already on the registry
+      # (partial-publish retry).
+      - name: Publish to npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${NAME}@${VERSION} already published -- skipping."
           else
-            echo "NPM_TAG=latest" >> $GITHUB_OUTPUT
-            echo "GIT_BRANCH_TARGET=main" >> $GITHUB_OUTPUT
+            npm publish --provenance --access public --ignore-scripts
           fi
 
-      - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          provenance: true
-          token: ${{ secrets.NPM_TOKEN }}
-          tag: ${{ steps.set-npm-tag.outputs.NPM_TAG }}
-
-  Update_Repo:
-    runs-on: ubuntu-latest
-    needs: ['Test', 'Strip_Version', 'Publish']
-    permissions:
-      contents: write
-      actions: write
-      checks: write
-    env:
-      CLEAN_TAG: ${{ needs.Strip_Version.outputs.CLEAN_TAG }}
-      GIT_BRANCH_TARGET: ${{ needs.Publish.outputs.GIT_BRANCH_TARGET }}
-    steps:
-      # - uses: hmarr/debug-action@v3
-
-      - uses: actions/checkout@v4
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          ref: ${{ env.GIT_BRANCH_TARGET }}
-          sparse-checkout: |
-            package.json
-            CHANGELOG.md
-          sparse-checkout-cone-mode: false
-
-      - name: Update Version in Package.json
-        id: set-git-branch
-        run: npm version $CLEAN_TAG --no-git-tag-version
-
-      - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
-        with:
-          latest-version: ${{ github.event.release.name }}
-          release-notes: ${{ github.event.release.body }}
-
-      - name: Commit and Push Version Update
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore(release): ${{ github.event.release.tag_name }} [skip ci]"
-
   Document:
-    needs: ['Update_Repo', 'Publish']
+    name: 📚 Publish Docs
+    needs: [Publish]
     uses: ./.github/workflows/action-docs.yaml

--- a/.github/workflows/action-docs.yaml
+++ b/.github/workflows/action-docs.yaml
@@ -21,9 +21,11 @@ jobs:
         uses: actions/checkout@v6
 
       # The repo does not commit a lockfile; generate one so the action's
-      # setup-node npm cache and `npm ci` have a lockfile to key on.
+      # setup-node npm cache and `npm ci` have a lockfile to key on. No
+      # --legacy-peer-deps: it resolves an inconsistent eslint tree (see
+      # action-test.yaml).
       - name: Generate lockfile
-        run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+        run: npm install --package-lock-only --ignore-scripts
 
       - name: Publish versioned docs
         uses: Bugs5382/typedoc-pages-action@v0.1.1

--- a/.github/workflows/action-docs.yaml
+++ b/.github/workflows/action-docs.yaml
@@ -3,104 +3,29 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# The composite action below restores prior versions, builds typedoc, and pushes
+# to gh-pages -- it needs contents: write.
 permissions:
   contents: write
-  actions: write
-  checks: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  History:
+  docs:
+    name: 📚 Publish Docs
     runs-on: ubuntu-latest
     steps:
-      - name: Get the gh-pages repo
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # The repo does not commit a lockfile; generate one so the action's
+      # setup-node npm cache and `npm ci` have a lockfile to key on.
+      - name: Generate lockfile
+        run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+
+      - name: Publish versioned docs
+        uses: Bugs5382/typedoc-pages-action@v0.1.1
         with:
-          ref: gh-pages
-
-      - name: Tar the existing docs
-        run: |
-          mkdir -p ./docs
-          tar -cvf documentation.tar ./docs
-
-      - name: Create a document artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation
-          path: documentation.tar
-
-  Build:
-    needs: History
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout src
-        uses: actions/checkout@v4
-
-      - name: Make Directory
-        run: mkdir -p ./docs
-
-      - name: Download the existing documents artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: documentation
-
-      - name: Tar Docs
-        run: tar -xf documentation.tar ./docs -C ./docs
-
-      - name: Build
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Install NPM
-        run: |
-          npm install --package-lock-only --force
-          npm install --ignore-scripts --force
-
-      - name: Build Documents
-        run: npm run typedoc
-
-      - name: Tar the new docs
-        run: tar -cvf newdocumentation.tar ./docs
-
-      - name: Create a new document artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: newdocumentation
-          path: newdocumentation.tar
-
-  Commit:
-    needs: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the gh-pages repo
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-
-      - name: Checkout the gh-pages repo
-        if: env.exists == 'true'
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-
-      - name: Create Directory
-        run: mkdir -p ./docs
-
-      - name: Download the new documents artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: newdocumentation
-        continue-on-error: true
-
-      - name: Extract Tar
-        run: tar -xf newdocumentation.tar ./docs -C ./docs
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          allow_empty_commit: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./docs
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -26,10 +26,11 @@ jobs:
         uses: actions/checkout@v6
 
       # Generate the lockfile BEFORE setup-node so its npm cache has something to
-      # key on. --legacy-peer-deps keeps CI in parity with local installs that
-      # rely on overrides / peer-dep workarounds.
+      # key on. No --legacy-peer-deps: it lets npm install an inconsistent tree
+      # (@the-rabbit-hole/eslint-config pulls @eslint/js@10 against eslint@9),
+      # which hangs eslint. The deps resolve cleanly without it.
       - name: Generate lockfile
-        run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+        run: npm install --package-lock-only --ignore-scripts
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -38,7 +39,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts --legacy-peer-deps
+        run: npm ci --ignore-scripts
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -3,20 +3,16 @@ on:
   workflow_dispatch:
   workflow_call:
   pull_request:
-    branches:
-      - main
-      - develop
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
-
-
+    branches: ["**"]
+    types: [opened, reopened, ready_for_review, synchronize]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
-
-  Build:
+  build:
+    name: 🧪 Build
     runs-on: ubuntu-latest
+    # The integration tests publish/consume against a real broker.
     services:
       rabbitmq:
         image: rabbitmq:4.0.2-alpine
@@ -26,38 +22,53 @@ jobs:
       matrix:
         node-version: [24.x, 'lts/*', 'latest']
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Test with Node ${{matrix.node-version}}
-        uses: actions/setup-node@v4
+      # Generate the lockfile BEFORE setup-node so its npm cache has something to
+      # key on. --legacy-peer-deps keeps CI in parity with local installs that
+      # rely on overrides / peer-dep workarounds.
+      - name: Generate lockfile
+        run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
         with:
-          node-version: ${{matrix.node-version}}
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
-      - name: Pre-Run
-        run: |
-          npm install --package-lock-only
-          npm install --ignore-scripts
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
 
-      - name: Run Tests and Lint
-        run: |
-          npm run lint
-          npm run test
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
         env:
           RABBITMQ_URL: amqp://guest:guest@localhost:5672
 
-      - name: Run Build
+      - name: Build
+        run: npm run build
+
+      # The published set is whatever package.json `files` lists (dist for an app,
+      # lib for a library) plus the fixed metadata. Derived, never hardcoded.
+      - name: Resolve published files
+        id: pkg
         run: |
-          npm run build
+          {
+            echo 'paths<<EOF'
+            echo 'package.json'
+            echo 'README.md'
+            echo 'LICENSE'
+            echo 'CHANGELOG.md'
+            node -p "(require('./package.json').files || ['dist']).join('\n')"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifact
         if: matrix.node-version == 'lts/*'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: cache
-          path: |
-            package.json
-            package-lock.json
-            README.md
-            LICENSE
-            CHANGELOG.md
-            dist
+          name: dist
+          path: ${{ steps.pkg.outputs.paths }}


### PR DESCRIPTION
## What and why

The `action-*` build/publish/deploy workflows are project-owned, so the additive governance sync never updated them — they were still on the pre-modernization pattern. This brings all three to the reference OIDC standard (matching fastify-hl7).

- **`action-deploy.yaml`** — publish to npm via **OIDC trusted publishing** (provenance, no `NPM_TOKEN`); idempotent (skip if that version is already on the registry); upgrade npm to >= 11.5.1, which trusted publishing requires. Removes the `Update_Repo` job — the Release Manager already bumps `package.json` and writes `CHANGELOG.md` on `main`, so re-doing it at release time double-counted. Stable-release-only trigger.
- **`action-docs.yaml`** — build versioned docs via the `Bugs5382/typedoc-pages-action` composite instead of the hand-rolled tar / checkout / `peaceiris` chain.
- **`action-test.yaml`** — modernized (`checkout@v6`, `setup-node@v6` + npm cache, lockfile then `npm ci`, `upload-artifact@v7`); the build artifact is renamed `cache` -> **`dist`** so the deploy job's download matches. The `rabbitmq` service and `RABBITMQ_URL` the integration tests need are retained.

## Closes

Closes #126

## Verification

- All three workflows parse as valid YAML.
- Artifact name now lines up end to end: the test job uploads `dist`, the deploy job downloads `dist`.
- The test workflow still provisions the `rabbitmq:4.0.2-alpine` service and sets `RABBITMQ_URL` for the integration suite.

## Closing summary

The publish path no longer requires an `NPM_TOKEN` and no longer re-bumps the version at release time; docs publish through the shared composite; and the build artifact name is consistent across test and deploy. This unblocks the release.

Release prep for #116.