### PR TITLE
ci: mirror the rabbitmq-client release tier on a dependency bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,14 @@ updates:
     labels:
       - dependencies
     groups:
+      # rabbitmq-client is the wrapped upstream; keep it in its own PR so a bump
+      # is unambiguous and the auto-merge workflow can promote it to a minor (or
+      # major) release on its own.
+      rabbitmq-client:
+        patterns: ["rabbitmq-client"]
       production-dependencies:
         dependency-type: production
+        exclude-patterns: ["rabbitmq-client"]
         update-types: [patch, minor, major]
       development-dependencies:
         dependency-type: development

--- a/.github/workflows/job-dependabot-auto-merge.yaml
+++ b/.github/workflows/job-dependabot-auto-merge.yaml
@@ -25,6 +25,25 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # rabbitmq-client is the wrapped upstream: app.rabbitmq re-exports its
+      # Connection wholesale, so the release mirrors the client's own bump --
+      # a major client bump is breaking, a minor is a feature. A patch keeps the
+      # default `dependencies` label and stays a patch.
+      - name: Promote a rabbitmq-client bump
+        if: contains(steps.metadata.outputs.dependency-names, 'rabbitmq-client')
+        run: |
+          case "${{ steps.metadata.outputs.update-type }}" in
+            version-update:semver-major)
+              gh pr edit "$PR_URL" --add-label breaking ;;
+            version-update:semver-minor)
+              gh pr edit "$PR_URL" --add-label enhancement ;;
+            *)
+              echo "rabbitmq-client patch bump -- keeping the default dependencies (patch) tier" ;;
+          esac
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
## What and why

`app.rabbitmq` re-exports the `rabbitmq-client` `Connection` wholesale, so a client update should bump this package by the **same semver tier**: a patch stays a patch, a minor cuts a minor, a major cuts a major. A minor client release surfaces new capabilities (a feature) and a major surfaces breaking changes (breaking) directly to consumers, even when the wrapper's own tests pass; a patch is an internal fix.

- **`dependabot.yml`** — isolate `rabbitmq-client` into its own group (and exclude it from `production-dependencies`) so its bump arrives as a single-dependency PR with an unambiguous update type.
- **`job-dependabot-auto-merge.yaml`** — after `fetch-metadata`, when the PR's dependency set includes `rabbitmq-client`, map the update type to a release-tier label the version-resolver acts on: `breaking` for a major, `enhancement` for a minor, and nothing for a patch (the default `dependencies` label keeps it a patch).

## Closes

Closes #128

## Verification

- `dependabot.yml` and the workflow parse as valid YAML.
- The label step is gated on `contains(dependency-names, 'rabbitmq-client')` and runs before auto-merge is enabled, so the tier label is on the PR at merge time for the version-resolver to read.

## Closing summary

A wrapped-client update now drives the release tier it deserves — patch for a patch, minor for a minor, major for a major — while every other dependency bump still resolves a patch.