### PR TITLE
docs: show how to encapsulate messaging in a Fastify plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ namespaces. The contract to respect:
 - **Namespaces for multiple brokers.** Register once per unique `namespace`; reach each at
   `app.rabbitmq.<namespace>`. Re-using a namespace throws `FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS`.
 - In a route, reach the instance via `request.server.rabbitmq`.
+- **Prefer encapsulating messaging in your own `fastify-plugin`.** Register this plugin there, declare
+  topology and publishers once at startup, expose an intent-named decorator (e.g. `app.events`) so
+  routes do not touch AMQP, and close consumers/publishers in an `onClose` hook. See the README recipe
+  "Encapsulate messaging in your own plugin".
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ contribution from the outside.
    3. [RPC (request/response)](#3-rpc-requestresponse)
    4. [Declare exchanges, queues, and bindings](#4-declare-exchanges-queues-and-bindings)
    5. [Multiple connections with namespaces](#5-multiple-connections-with-namespaces)
+   6. [Encapsulate messaging in your own plugin](#6-encapsulate-messaging-in-your-own-plugin)
 4. [API Reference](#-api-reference-fastifyrabbitmq)
 5. [Plugin Options](#-plugin-options)
 6. [External Libraries](#-external-libraries)
@@ -135,6 +136,105 @@ const pubB = app.rabbitmq.b.createPublisher();
 ```
 
 Registering the same namespace twice throws `FASTIFY_RABBIT_MQ_ERR_SETUP_ERRORS`.
+
+### 6. Encapsulate messaging in your own plugin
+
+This is the pattern the plugin is built for, and the reason it is a plugin at all.
+Fastify's encapsulation lets you keep every messaging concern — the connection, the
+topology, the publishers, the consumers, and their shutdown — in **one plugin**, and
+expose just a small, intent-named surface (a decorator like `app.events`) to the rest
+of the app. Your routes publish business events; they never see exchanges, routing
+keys, or the AMQP client.
+
+Wrap it with [`fastify-plugin`](https://github.com/fastify/fastify-plugin) so the
+decorator is visible to sibling plugins and routes (without `fp`, the decorator would
+be trapped inside this plugin's encapsulation context):
+
+```ts
+// plugins/messaging.ts
+import fp from "fastify-plugin";
+import fastifyRabbitMQ from "fastify-rabbitmq";
+import type { Publisher } from "rabbitmq-client";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    events: Publisher;
+  }
+}
+
+export default fp(
+  async (app) => {
+    // 1. Open the connection.
+    await app.register(fastifyRabbitMQ, {
+      connection: process.env.RABBITMQ_URL ?? "amqp://guest:guest@localhost",
+    });
+
+    // 2. Declare the topology and a publisher once, at startup. The publisher
+    //    re-declares these on every reconnect, so the exchange always exists
+    //    before the first send.
+    const publisher = app.rabbitmq.createPublisher({
+      confirm: true,
+      maxAttempts: 2,
+      exchanges: [{ exchange: "events", type: "topic" }],
+    });
+
+    // 3. Expose one intent-named sender. Routes call app.events.send(...) and
+    //    stay ignorant of AMQP.
+    app.decorate("events", publisher);
+
+    // 4. Run consumers as part of the app lifecycle. The consumer manages its
+    //    own channel and re-subscribes across reconnects.
+    const consumer = app.rabbitmq.createConsumer(
+      {
+        queue: "user-events",
+        queueOptions: { durable: true },
+        queueBindings: [{ exchange: "events", routingKey: "user.#" }],
+      },
+      async (msg) => {
+        app.log.info({ body: msg.body }, "user event");
+        // ...handle the message; throw to nack/retry...
+      },
+    );
+
+    // 5. Tear everything down with the app, so a restart or test closes
+    //    cleanly instead of leaking connections.
+    app.addHook("onClose", async () => {
+      await consumer.close();
+      await publisher.close();
+    });
+  },
+  { name: "messaging" },
+);
+```
+
+Register it once, then publish from anywhere:
+
+```ts
+import messaging from "./plugins/messaging";
+
+await app.register(messaging);
+
+app.post("/signup", async (request, reply) => {
+  await app.events.send(
+    { exchange: "events", routingKey: "user.created" },
+    request.body,
+  );
+  return { accepted: true };
+});
+```
+
+Why this shape works well:
+
+- **One place owns messaging.** Connection, topology, publishers, consumers, and
+  shutdown live together; the rest of the app depends only on `app.events`.
+- **Startup declares, routes send.** Topology is declared once at boot, so the first
+  request never races a missing exchange.
+- **Lifecycle is handled.** The `onClose` hook closes the consumer and publisher with
+  the app — important for graceful shutdown and for tests that start and stop Fastify
+  repeatedly.
+- **Swappable.** Because routes only know `app.events`, you can change brokers, add a
+  [namespace](#5-multiple-connections-with-namespaces), or stub the decorator in a test
+  without touching route code.
 
 ## 📖 API Reference (`fastify.rabbitmq`)
 


### PR DESCRIPTION
## What and why

Adds the recipe the plugin is built for: wrap messaging in your own `fastify-plugin` and expose a small, intent-named surface to the rest of the app. The existing recipes cover the primitives (publish, consume, RPC, topology, namespaces) but not the composition that makes the plugin worth using — keeping the connection, topology, publishers, consumers, and shutdown in one place so routes publish business events and never see exchanges or the AMQP client.

The recipe walks through it end to end with the reasoning for each step:
- wrap with `fastify-plugin` so the decorator is visible app-wide;
- declare topology and a publisher once at startup (re-declared on reconnect);
- decorate an intent-named sender (`app.events`);
- run a consumer;
- close both in an `onClose` hook for graceful shutdown and clean tests.

AGENTS.md gets a pointer so an integrating agent starts from this pattern.

## Closes

Closes #130

## Verification

- Recipe added under Recipes as item 6 with a matching table-of-contents entry.
- Code sample uses the documented `app.rabbitmq` surface (`createPublisher`, `createConsumer`) and the `request.server` access already described elsewhere in the README.

## Closing summary

Integrators now have a concrete, idiomatic blueprint for a messaging layer instead of only the low-level calls.