### PR TITLE
feat: re-export the rabbitmq-client types from fastify-rabbitmq

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,4 +108,32 @@ export default fastifyRabbit;
 export { decorateFastifyInstance };
 
 export * from "./types";
-export { type ConnectionOptions } from "rabbitmq-client";
+
+// Re-export the rabbitmq-client surface so consumers import from this package
+// instead of reaching for the wrapped client. These are the exact types the
+// app.rabbitmq decorator hands back, so they stay correct without owning a
+// parallel definition.
+export type {
+  AsyncMessage,
+  Channel,
+  Connection,
+  ConnectionOptions,
+  Consumer,
+  ConsumerHandler,
+  ConsumerProps,
+  Envelope,
+  HeaderFields,
+  MessageBody,
+  Publisher,
+  PublisherProps,
+  ReturnedMessage,
+  RPCClient,
+  RPCProps,
+  SyncMessage,
+} from "rabbitmq-client";
+export {
+  AMQPChannelError,
+  AMQPConnectionError,
+  AMQPError,
+  ConsumerStatus,
+} from "rabbitmq-client";


### PR DESCRIPTION
## What and why

`app.rabbitmq` and the objects it returns are `rabbitmq-client`'s, and the contract is already "don't import `rabbitmq-client` directly." This extends that to types: re-export `Publisher`, `PublisherProps`, `Consumer`, `ConsumerProps`, `ConsumerHandler`, `RPCClient`, `RPCProps`, `Channel`, `Connection`, `ConnectionOptions`, `Envelope`, the message types (`AsyncMessage`, `SyncMessage`, `ReturnedMessage`, `MessageBody`, `HeaderFields`), and the error classes (`AMQPError`, `AMQPConnectionError`, `AMQPChannelError`, `ConsumerStatus`) from the package entry.

Consumers now write `import type { Publisher } from "fastify-rabbitmq"` and never reach into the wrapped client. These are the exact types the decorator hands back, so re-exporting keeps one import surface without owning a parallel definition that would drift from the real objects.

## Closes

Closes #134

## Verification

- `npm run lint` clean; `npm run build` succeeds (the re-exported names all resolve against `rabbitmq-client`).

## Notes

The messaging recipe's `import type { Publisher }` is flipped to `fastify-rabbitmq` on the docs PR (#131); that import resolves once this lands, so merge this first.

## Closing summary

The package now owns its import surface for the wrapped client's types while keeping them in lockstep with the dependency.