### PR TITLE
docs: point consumers at the re-exported client types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ If you are an agent wiring this plugin into a Fastify app (not editing this repo
 namespaces. The contract to respect:
 
 - **Single entry point.** Register the plugin (`await app.register(fastifyRabbitMQ, opts)`) and use
-  the `app.rabbitmq` decorator. Do not import `rabbitmq-client` directly in app code.
+  the `app.rabbitmq` decorator. Do not import `rabbitmq-client` directly in app code — its types
+  (`Publisher`, `Consumer`, `RPCClient`, `Connection`, `ConnectionOptions`, `Envelope`, the message
+  types, and the AMQP error classes) are re-exported from `fastify-rabbitmq`.
 - **`app.rabbitmq` is the full Connection.** It exposes the underlying `rabbitmq-client` `Connection`
   API directly (`createPublisher`, `createConsumer`, `createRPCClient`, `exchangeDeclare`,
   `queueDeclare`, `queueBind`, `acquire`, `ready`, `close`) — nothing is wrapped away.

--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ be trapped inside this plugin's encapsulation context):
 ```ts
 // plugins/messaging.ts
 import fp from "fastify-plugin";
-import fastifyRabbitMQ from "fastify-rabbitmq";
-import type { Publisher } from "rabbitmq-client";
+import fastifyRabbitMQ, { type Publisher } from "fastify-rabbitmq";
 
 declare module "fastify" {
   interface FastifyInstance {
@@ -235,6 +234,10 @@ Why this shape works well:
 - **Swappable.** Because routes only know `app.events`, you can change brokers, add a
   [namespace](#5-multiple-connections-with-namespaces), or stub the decorator in a test
   without touching route code.
+
+> The types you need — `Publisher`, `Consumer`, `RPCClient`, `Connection`, `ConnectionOptions`,
+> `Envelope`, the message types, and the AMQP error classes — are re-exported from
+> `fastify-rabbitmq`. Import them from here, not from `rabbitmq-client`.
 
 ## 📖 API Reference (`fastify.rabbitmq`)
 


### PR DESCRIPTION
## What and why

The package re-exports the `rabbitmq-client` types (#134 / #135), so the docs should demonstrate importing them from `fastify-rabbitmq`. The messaging recipe now imports `Publisher` from `fastify-rabbitmq`, a note lists the re-exported types, and the AGENTS contract says to import types from this package rather than reaching into the wrapped client.

## Closes

Closes #136

## Verification

- Recipe import resolves against the re-export merged in #135.

## Closing summary

Consumers have one import surface for both the plugin and the client types it returns.