### PR TITLE
ci: Release Manager commits as the owner, not github-actions[bot]

### DIFF
--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -92,3 +92,8 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(pre-release): v${{ steps.drafter.outputs.resolved_version }} [skip ci]"
+          # Commit as the triggering owner, not github-actions[bot]; the push
+          # still uses the release App token to bypass the [skip ci] rule.
+          commit_user_name: ${{ github.actor }}
+          commit_user_email: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+          commit_author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Set the git-auto-commit identity to the triggering actor (`github.actor` + ID-linked noreply) so `chore(pre-release)` deploy commits are attributed to the owner, not `github-actions[bot]`. Push still uses the release App token to bypass `[skip ci]`. Closes #145