### PR TITLE
chore: drop ci entries with no heading from v3.4.1/v3.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### What Changed 👀
 
-- ci: Release Manager commits as the owner, not github-actions[bot] @Bugs5382 (#146)
-
 #### 🧩 Dependency Updates
 
 - build(deps): bump the github-actions group with 9 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#143)
@@ -73,8 +71,6 @@
 ## v3.1.0 - 2024-11-17
 
 #### What Changed 👀
-
-- ci: update workflows @Bugs5382 (#103)
 
 #### 🧩 Dependency Updates
 


### PR DESCRIPTION
## What and why

PRs #146 (v3.4.1) and #103 (v3.1.0) were `ci:` changes that merged without a `skip-changelog` label, so release-drafter listed them as uncategorized entries with no heading. Both are now relabeled, and this removes them from CHANGELOG.md. The v3.4.1 draft body is corrected; the published v3.1.0 body will be fixed separately.

Closes #154

## Verification

- [x] v3.4.1 and v3.1.0 sections no longer list the ci: PRs
- [x] v3.4.1 release draft corrected

## How this was verified

Reviewed both sections after the edit.